### PR TITLE
Configurable count using `nomad-pipeline/count` tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ group "2-second-task-group" {
 
 **Run tasks in parallel**
 
+***Using dependencies***
+
 To support running tasks in parallel and having a final task that runs at the end of all parallel tasks (eg. fan-out fan-in pattern), you can use the `nomad-pipeline/dependencies` tag.
 
 ```mermaid
@@ -99,6 +101,14 @@ group "E" {
 ```
 
 See [`dependencies.hcl`](examples/dependencies.hcl) for a more complete example.
+
+***Using count***
+
+Another way to implement the fan-out fan-in pattern is to have multiple instances of a task group that can all pick up some work. Without nomad-pipeline, this is quite easy, you just set the [`count` stanza](https://www.nomadproject.io/docs/job-specification/group#count) on the task group. However, when using nomad-pipeline, the control of count is not in your hands. So if you want to set a count greater than 1, you can set the `nomad-pipeline/count` tag.
+
+> 💡 *Tip: The [`count` stanza](https://www.nomadproject.io/docs/job-specification/group#count) doesn't support variable interpolation since the config value is an integer and not a string - currently Nomad only support variable interpolation for string config values. This means that `count` can't be set from a `NOMAD_META_` variable, which is required for setting the `count` dynamically in a parameterized job. Using the `nomad-pipeline/count` tag allows you work around this. All `nomad-pipeline/*` tags interpolates variables, so you can use something like `"nomad-pipeline/count" = "${NOMAD_META_count}"`*
+
+See [`examples/fan-out-fan-in.hcl`](examples/fan-out-fan-in.hcl) for a more complete example.
 
 **Dynamic tasks**
 

--- a/examples/fan-out-fan-in.hcl
+++ b/examples/fan-out-fan-in.hcl
@@ -1,0 +1,136 @@
+variable "datacenters" {
+  type    = list(string)
+  default = ["dc1"]
+}
+
+variable "image" {
+  type    = string
+  default = "ghcr.io/hyperbadger/nomad-pipeline:main"
+}
+
+variable "nomad_addr" {
+  type    = string
+  default = "http://host.docker.internal:4646"
+}
+
+variable "docker_extra_hosts" {
+  type    = list(string)
+  default = ["host.docker.internal:host-gateway"]
+}
+
+job "fan-out-fan-in" {
+  name        = "fan-out-fan-in"
+  datacenters = var.datacenters
+  type        = "batch"
+
+  group "▶️" {
+    task "init" {
+      driver = "docker"
+
+      config {
+        image = var.image
+        args  = ["-init"]
+
+        extra_hosts    = var.docker_extra_hosts
+        auth_soft_fail = true
+      }
+
+      env {
+        NOMAD_ADDR           = var.nomad_addr
+        NOMAD_PIPELINE_DEBUG = "true"
+      }
+    }
+  }
+
+  group "1-submit-tasks" {
+    count = 0
+
+    meta = {
+      "nomad-pipeline/root" = "true"
+      "nomad-pipeline/next" = "2-do-work"
+    }
+
+    task "submit" {
+      driver = "raw_exec"
+
+      config {
+      command = "/bin/bash"
+        args = ["local/main.sh"]
+      }
+
+      template {
+        data = <<-EOT
+        #!/bin/bash
+
+        sleep 5
+        echo "alot of work" > queue
+
+        EOT
+
+        destination = "local/main.sh"
+      }
+    }
+  }
+
+  group "2-do-work" {
+    count = 0
+
+    meta = {
+      "nomad-pipeline/count" = "5"
+      "nomad-pipeline/next"  = "3-process-output"
+    }
+
+    scaling {
+      enabled = true
+      max     = 10
+    }
+
+    task "work" {
+      driver = "raw_exec"
+
+      config {
+      command = "/bin/bash"
+        args = ["local/main.sh"]
+      }
+
+      template {
+        data = <<-EOT
+        #!/bin/bash
+
+        echo "pick things off queue and do work"
+        sleep 10
+        # sleep $((5 + RANDOM % 20));
+
+        EOT
+
+        destination = "local/main.sh"
+      }
+    }
+  }
+
+  group "3-process-output" {
+    count = 0
+
+    meta = {
+      "nomad-pipeline/dependencies" = "2-do-work"
+    }
+
+    task "process" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args = ["local/main.sh"]
+      }
+
+      template {
+        data = <<-EOT
+        #!/bin/bash
+        echo "process output of work"
+        EOT
+
+        destination = "local/main.sh"
+      }
+    }
+  }
+}


### PR DESCRIPTION
A task groups count config is controlled by nomad-pipeline. Prior to this change, the count value can only be 1. This new tag allows that count to be configurable allowing support for cases where you need to have a count value of more than 1.

Also includes a nice example of when you might need to use this tag.