### PR TITLE
URL friendly versions of Nomad environment variables

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,10 @@ name: Docker
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - f-*
+      - b-*
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/README.md
+++ b/README.md
@@ -177,3 +177,9 @@ group "1-generate-tasks" {
 ```
 
 See [`dynamic-job.hcl`](examples/dynamic-job.hcl) for a more complete example.
+
+**URL Friendly Nomad Environment Variables**
+
+There are many useful [Nomad environment variables](https://www.nomadproject.io/docs/runtime/interpolation#interpreted_env_vars) that can be used at runtime and in config fields that support variable interpolation. However, in some cases, some of these environment variables are not URL friendly - in the case of parameterized jobs, the dispatched job's ID (`NOMAD_JOB_ID`) and name (`NOMAD_JOB_NAME`) will have a `/` in them. URL friendly versions of these variables are required when using them in the [`service` stanza](https://www.nomadproject.io/docs/job-specification/service#name). To allow for this, a URL friendly version of the `NOMAD_JOB_ID` and `NOMAD_JOB_NAME` can be found under `NOMAD_META_JOB_ID_SLUG` and `NOMAD_META_JOB_ID_SLUG` - the inspiration for `_SLUG` came from [Gitlab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html). These meta variables are injected at the job level by the init task of nomad-pipeline, making them available to all the task groups that come after it.
+
+Although this feature was added specifically for use with the [`service` stanza](https://www.nomadproject.io/docs/job-specification/service#name), it could prove useful for other config fields. Note to developer: nomad-pipeline might not be the right vehicle for this feature, however the init task was a convenient place to put this functionality.


### PR DESCRIPTION
Injects URL friendly versions of `NOMAD_JOB_ID` and `NOMAD_JOB_NAME` into the job's meta and is available in task groups as `NOMAD_META_JOB_ID_SLUG` and `NOMAD_META_JOB_NAME_SLUG`.