### PR TITLE
Pull more settings from env for nomad client

### DIFF
--- a/pkg/controller/pipeline.go
+++ b/pkg/controller/pipeline.go
@@ -363,6 +363,8 @@ func NewPipelineController(cPath string) *PipelineController {
 
 	nClient, err := nomad.NewClient(&nomad.Config{
 		Address: os.Getenv("NOMAD_ADDR"),
+		Namespace: os.Getenv("NOMAD_NAMESPACE"),
+		Region: os.Getenv("NOMAD_REGION"),
 	})
 	if err != nil {
 		log.Fatalf("error creating client: %v", err)


### PR DESCRIPTION
Nomad Client for some users relies on Namespace and Region to correctly execute requests.

Default Config actually does set `.namespace` and `.region` to their env-var equivalents. Unfortunately in the `nomad.NewClient` function only the address is set to the env-var value, if it's empty. No such checks are made for other (non-crucial) fields.